### PR TITLE
dma: bugfix for clear_flags

### DIFF
--- a/hal/src/dma/mod.rs
+++ b/hal/src/dma/mod.rs
@@ -152,11 +152,12 @@ impl DmaCh {
     /// ```
     pub fn flags(&self) -> u8 {
         let raw: u32 = unsafe { read_volatile(self.isr) };
-        ((raw >> (4 * self.ch)) & 0xF) as u8
+        ((raw >> self.ch.mul(4)) & 0xF) as u8
     }
 
     fn clear_flags(&mut self, flags: u8) {
-        unsafe { write_volatile(self.ifcr, (flags & 0xF) as u32) }
+        let val: u32 = u32::from(flags & 0xF) << self.ch.mul(4);
+        unsafe { write_volatile(self.ifcr, val) }
     }
 
     pub(crate) fn clear_all_flags(&mut self) {

--- a/hal/src/dma/mod.rs
+++ b/hal/src/dma/mod.rs
@@ -16,7 +16,10 @@
 
 mod cr;
 
-use core::ptr::{read_volatile, write_volatile};
+use core::{
+    ops::Mul,
+    ptr::{read_volatile, write_volatile},
+};
 
 use super::pac;
 


### PR DESCRIPTION
All DMA channels were clearing DMA channel 1's flags instead of their own.