### PR TITLE
subghz-testsuite: fix for non-aio

### DIFF
--- a/hal/src/subghz/mod.rs
+++ b/hal/src/subghz/mod.rs
@@ -280,6 +280,7 @@ impl<DMA> SubGhz<DMA> {
         self.debug_pins.is_some()
     }
 
+    #[cfg(feature = "aio")]
     fn setup_rfbusy_irq() {
         let dp: pac::Peripherals = unsafe { pac::Peripherals::steal() };
         dp.EXTI.ftsr2.modify(|_, w| w.ft45().enabled());

--- a/hal/src/subghz/mod.rs
+++ b/hal/src/subghz/mod.rs
@@ -485,8 +485,13 @@ impl SubGhz<DmaCh> {
         while !rfbusys() {}
         Nss::set();
 
+        #[cfg(feature = "aio")]
         Self::setup_rfbusy_irq();
-        unsafe { unmask_irq() };
+
+        #[cfg(feature = "aio")]
+        unsafe {
+            unmask_irq()
+        };
 
         SubGhz {
             spi,

--- a/subghz-testsuite/tests/test.rs
+++ b/subghz-testsuite/tests/test.rs
@@ -18,8 +18,8 @@ use bsp::{
         rcc,
         rng::{self, Rng},
         subghz::{
-            AddrComp, CalibrateImage, CmdStatus, CodingRate, CrcType, FskBandwidth, FskBitrate,
-            FskFdev, FskModParams, FskPulseShape, GenericPacketParams, HeaderType, Irq,
+            AddrComp, CalibrateImage, CfgIrq, CmdStatus, CodingRate, CrcType, FskBandwidth,
+            FskBitrate, FskFdev, FskModParams, FskPulseShape, GenericPacketParams, HeaderType, Irq,
             LoRaBandwidth, LoRaModParams, LoRaPacketParams, LoRaSyncWord, Ocp, PaConfig, PaSel,
             PacketType, PreambleDetection, RampTime, RegMode, RfFreq, SpreadingFactor, StandbyClk,
             Status, StatusMode, SubGhz, TcxoMode, TcxoTrim, Timeout, TxParams,
@@ -134,8 +134,6 @@ async fn aio_wait_irq_inner() {
         .unwrap();
     sg.aio_set_rf_frequency(&RF_FREQ).await.unwrap();
 
-    use bsp::hal::subghz::CfgIrq;
-
     const IRQ_CFG: CfgIrq = CfgIrq::new()
         .irq_enable(Irq::RxDone)
         .irq_enable(Irq::Timeout);
@@ -213,6 +211,11 @@ fn ping_pong(sg: &mut SubGhz<DmaCh>, rng: &mut Rng, rfs: &mut RfSwitch, pkt: Pac
     sg.set_rf_frequency(&RF_FREQ).unwrap();
 
     sg.write_buffer(TX_BUF_OFFSET, PING_DATA_BYTES).unwrap();
+
+    const IRQ_CFG: CfgIrq = CfgIrq::new()
+        .irq_enable(Irq::RxDone)
+        .irq_enable(Irq::Timeout);
+    sg.set_irq_cfg(&IRQ_CFG).unwrap();
 
     const MAX_ATTEMPTS: u32 = 100;
     let mut attempt: u32 = 0;


### PR DESCRIPTION
The testsuite broke on stable (compiled but failed when run)
because the on-target CI was accidentally testing on nightly
twice instead of once on stable and once on nightly.