### PR TITLE
Fix bug in  GPIO AF shift for pins > 7

### DIFF
--- a/hal/src/gpio.rs
+++ b/hal/src/gpio.rs
@@ -69,7 +69,7 @@ impl<const BASE: usize, const N: u8> Pin<BASE, N> {
     const AF: usize = if N > 7 { BASE + 0x24 } else { BASE + 0x20 };
     const AF_R: *const u32 = Self::AF as *const u32;
     const AF_W: *mut u32 = Self::AF as *mut u32;
-    const AF_SHIFT: u8 = if N > 7 { (N - 7) * 4 } else { N * 4 };
+    const AF_SHIFT: u8 = if N > 7 { (N - 8) * 4 } else { N * 4 };
 
     pub(crate) const fn new() -> Pin<BASE, N> {
         Pin {}


### PR DESCRIPTION
The `AF_SHIFT` constant for each pin is calculated wrong for pin numbers above 7 that go in the `AFRH` register. In the current implementation, the shift is 4 bits larger than it should be: `(N - 7) * 4`. This yields:
* shift = 4 for N=8, when it should yield 0 (no shift)
* shift = 32 for N=15, when if should yield 28 (highest 4 bits)

