### PR TITLE
Use super for importing dependencies

### DIFF
--- a/hal/src/subghz/cad_params.rs
+++ b/hal/src/subghz/cad_params.rs
@@ -1,4 +1,4 @@
-use crate::subghz::Timeout;
+use super::Timeout;
 
 /// Number of symbols used for channel activity detection scans.
 ///

--- a/hal/src/subghz/hse_trim.rs
+++ b/hal/src/subghz/hse_trim.rs
@@ -1,4 +1,4 @@
-use crate::subghz::ValueError;
+use super::ValueError;
 
 /// HSE32 load capacitor trimming.
 ///

--- a/hal/src/subghz/ocp.rs
+++ b/hal/src/subghz/ocp.rs
@@ -2,7 +2,7 @@
 ///
 /// Used by [`set_pa_ocp`].
 ///
-/// [`set_pa_ocp`]: crate::subghz::SubGhz::set_pa_ocp
+/// [`set_pa_ocp`]: super::SubGhz::set_pa_ocp
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]

--- a/hal/src/subghz/op_error.rs
+++ b/hal/src/subghz/op_error.rs
@@ -2,7 +2,7 @@
 ///
 /// Returned by [`op_error`].
 ///
-/// [`op_error`]: crate::subghz::SubGhz::op_error
+/// [`op_error`]: super::SubGhz::op_error
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]

--- a/hal/src/subghz/pa_config.rs
+++ b/hal/src/subghz/pa_config.rs
@@ -2,7 +2,7 @@
 ///
 /// Argument of [`set_pa_config`].
 ///
-/// [`set_pa_config`]: crate::subghz::SubGhz::set_pa_config
+/// [`set_pa_config`]: super::SubGhz::set_pa_config
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PaConfig {
@@ -12,7 +12,7 @@ pub struct PaConfig {
 impl PaConfig {
     /// Optimal settings for +15dBm output power with the low-power PA.
     ///
-    /// This must be used with [`TxParams::LP_15`](crate::subghz::TxParams::LP_15).
+    /// This must be used with [`TxParams::LP_15`](super::TxParams::LP_15).
     pub const LP_15: PaConfig = PaConfig::new()
         .set_pa_duty_cycle(0x6)
         .set_hp_max(0x0)
@@ -20,7 +20,7 @@ impl PaConfig {
 
     /// Optimal settings for +14dBm output power with the low-power PA.
     ///
-    /// This must be used with [`TxParams::LP_14`](crate::subghz::TxParams::LP_14).
+    /// This must be used with [`TxParams::LP_14`](super::TxParams::LP_14).
     pub const LP_14: PaConfig = PaConfig::new()
         .set_pa_duty_cycle(0x4)
         .set_hp_max(0x0)
@@ -28,7 +28,7 @@ impl PaConfig {
 
     /// Optimal settings for +10dBm output power with the low-power PA.
     ///
-    /// This must be used with [`TxParams::LP_10`](crate::subghz::TxParams::LP_10).
+    /// This must be used with [`TxParams::LP_10`](super::TxParams::LP_10).
     pub const LP_10: PaConfig = PaConfig::new()
         .set_pa_duty_cycle(0x1)
         .set_hp_max(0x0)
@@ -36,7 +36,7 @@ impl PaConfig {
 
     /// Optimal settings for +22dBm output power with the high-power PA.
     ///
-    /// This must be used with [`TxParams::HP`](crate::subghz::TxParams::HP).
+    /// This must be used with [`TxParams::HP`](super::TxParams::HP).
     pub const HP_22: PaConfig = PaConfig::new()
         .set_pa_duty_cycle(0x4)
         .set_hp_max(0x7)
@@ -44,7 +44,7 @@ impl PaConfig {
 
     /// Optimal settings for +20dBm output power with the high-power PA.
     ///
-    /// This must be used with [`TxParams::HP`](crate::subghz::TxParams::HP).
+    /// This must be used with [`TxParams::HP`](super::TxParams::HP).
     pub const HP_20: PaConfig = PaConfig::new()
         .set_pa_duty_cycle(0x3)
         .set_hp_max(0x5)
@@ -52,7 +52,7 @@ impl PaConfig {
 
     /// Optimal settings for +17dBm output power with the high-power PA.
     ///
-    /// This must be used with [`TxParams::HP`](crate::subghz::TxParams::HP).
+    /// This must be used with [`TxParams::HP`](super::TxParams::HP).
     pub const HP_17: PaConfig = PaConfig::new()
         .set_pa_duty_cycle(0x2)
         .set_hp_max(0x3)
@@ -60,7 +60,7 @@ impl PaConfig {
 
     /// Optimal settings for +14dBm output power with the high-power PA.
     ///
-    /// This must be used with [`TxParams::HP`](crate::subghz::TxParams::HP).
+    /// This must be used with [`TxParams::HP`](super::TxParams::HP).
     pub const HP_14: PaConfig = PaConfig::new()
         .set_pa_duty_cycle(0x2)
         .set_hp_max(0x2)

--- a/hal/src/subghz/packet_params.rs
+++ b/hal/src/subghz/packet_params.rs
@@ -76,7 +76,7 @@ pub enum CrcType {
 
 /// Packet parameters for [`set_packet_params`].
 ///
-/// [`set_packet_params`]: crate::subghz::SubGhz::set_packet_params
+/// [`set_packet_params`]: super::SubGhz::set_packet_params
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct GenericPacketParams {
@@ -311,7 +311,7 @@ impl Default for GenericPacketParams {
 
 /// Packet parameters for [`set_lora_packet_params`].
 ///
-/// [`set_lora_packet_params`]: crate::subghz::SubGhz::set_lora_packet_params
+/// [`set_lora_packet_params`]: super::SubGhz::set_lora_packet_params
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LoRaPacketParams {
     buf: [u8; 7],
@@ -470,7 +470,7 @@ impl Default for LoRaPacketParams {
 
 /// Packet parameters for [`set_lora_packet_params`].
 ///
-/// [`set_lora_packet_params`]: crate::subghz::SubGhz::set_lora_packet_params
+/// [`set_lora_packet_params`]: super::SubGhz::set_lora_packet_params
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BpskPacketParams {

--- a/hal/src/subghz/packet_status.rs
+++ b/hal/src/subghz/packet_status.rs
@@ -1,12 +1,12 @@
 use crate::Ratio;
 
-use crate::subghz::Status;
+use super::Status;
 
 /// (G)FSK packet status.
 ///
 /// Returned by [`fsk_packet_status`].
 ///
-/// [`fsk_packet_status`]: crate::subghz::SubGhz::fsk_packet_status
+/// [`fsk_packet_status`]: super::SubGhz::fsk_packet_status
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FskPacketStatus {
     buf: [u8; 4],
@@ -171,7 +171,7 @@ impl core::fmt::Display for FskPacketStatus {
 ///
 /// Returned by [`lora_packet_status`].
 ///
-/// [`lora_packet_status`]: crate::subghz::SubGhz::lora_packet_status
+/// [`lora_packet_status`]: super::SubGhz::lora_packet_status
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LoRaPacketStatus {
     buf: [u8; 4],

--- a/hal/src/subghz/packet_type.rs
+++ b/hal/src/subghz/packet_type.rs
@@ -2,7 +2,7 @@
 ///
 /// Argument of [`set_packet_type`]
 ///
-/// [`set_packet_type`]: crate::subghz::SubGhz::set_packet_type
+/// [`set_packet_type`]: super::SubGhz::set_packet_type
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/hal/src/subghz/pkt_ctrl.rs
+++ b/hal/src/subghz/pkt_ctrl.rs
@@ -22,7 +22,7 @@ impl Default for InfSeqSel {
 
 /// Generic packet control.
 ///
-/// Argument of [`set_pkt_ctrl`](crate::subghz::SubGhz::set_pkt_ctrl).
+/// Argument of [`set_pkt_ctrl`](super::SubGhz::set_pkt_ctrl).
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PktCtrl {

--- a/hal/src/subghz/pmode.rs
+++ b/hal/src/subghz/pmode.rs
@@ -2,7 +2,7 @@
 ///
 /// Argument of [`set_rx_gain`].
 ///
-/// [`set_rx_gain`]: crate::subghz::SubGhz::set_rx_gain
+/// [`set_rx_gain`]: super::SubGhz::set_rx_gain
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/hal/src/subghz/pwr_ctrl.rs
+++ b/hal/src/subghz/pwr_ctrl.rs
@@ -46,7 +46,7 @@ impl Default for CurrentLim {
 
 /// Power control.
 ///
-/// Argument of [`set_bit_sync`](crate::subghz::SubGhz::set_bit_sync).
+/// Argument of [`set_bit_sync`](super::SubGhz::set_bit_sync).
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PwrCtrl {

--- a/hal/src/subghz/rf_frequency.rs
+++ b/hal/src/subghz/rf_frequency.rs
@@ -2,7 +2,7 @@
 ///
 /// Argument of [`set_rf_frequency`].
 ///
-/// [`set_rf_frequency`]: crate::subghz::SubGhz::set_rf_frequency
+/// [`set_rf_frequency`]: super::SubGhz::set_rf_frequency
 #[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RfFreq {

--- a/hal/src/subghz/rx_timeout_stop.rs
+++ b/hal/src/subghz/rx_timeout_stop.rs
@@ -2,7 +2,7 @@
 ///
 /// Used by [`set_rx_timeout_stop`].
 ///
-/// [`set_rx_timeout_stop`]: crate::subghz::SubGhz::set_rx_timeout_stop
+/// [`set_rx_timeout_stop`]: super::SubGhz::set_rx_timeout_stop
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]

--- a/hal/src/subghz/sleep_cfg.rs
+++ b/hal/src/subghz/sleep_cfg.rs
@@ -27,7 +27,7 @@ impl Default for Startup {
 ///
 /// Argument of [`set_sleep`].
 ///
-/// [`set_sleep`]: crate::subghz::SubGhz::set_sleep
+/// [`set_sleep`]: super::SubGhz::set_sleep
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SleepCfg(u8);

--- a/hal/src/subghz/smps.rs
+++ b/hal/src/subghz/smps.rs
@@ -1,6 +1,6 @@
 /// SMPS maximum drive capability.
 ///
-/// Argument of [`set_smps_drv`](crate::subghz::SubGhz::set_smps_drv).
+/// Argument of [`set_smps_drv`](super::SubGhz::set_smps_drv).
 #[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]

--- a/hal/src/subghz/standby_clk.rs
+++ b/hal/src/subghz/standby_clk.rs
@@ -2,7 +2,7 @@
 ///
 /// Used by [`set_standby`].
 ///
-/// [`set_standby`]: crate::subghz::SubGhz::set_standby
+/// [`set_standby`]: super::SubGhz::set_standby
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]

--- a/hal/src/subghz/stats.rs
+++ b/hal/src/subghz/stats.rs
@@ -152,7 +152,7 @@ impl core::fmt::Display for Stats<FskStats> {
 
 #[cfg(test)]
 mod test {
-    use super::{CmdStatus, LoRaStats, Stats, StatusMode};
+    use super::super::{CmdStatus, LoRaStats, Stats, StatusMode};
 
     #[test]
     fn mixed() {

--- a/hal/src/subghz/stats.rs
+++ b/hal/src/subghz/stats.rs
@@ -1,4 +1,4 @@
-use crate::subghz::Status;
+use super::Status;
 
 typestate!(LoRaStats, "LoRa stats");
 typestate!(FskStats, "FSK stats");
@@ -7,8 +7,8 @@ typestate!(FskStats, "FSK stats");
 ///
 /// Returned by [`fsk_stats`] and [`lora_stats`].
 ///
-/// [`fsk_stats`]: crate::subghz::SubGhz::fsk_stats
-/// [`lora_stats`]: crate::subghz::SubGhz::lora_stats
+/// [`fsk_stats`]: super::SubGhz::fsk_stats
+/// [`lora_stats`]: super::SubGhz::lora_stats
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Stats<ModType> {
@@ -152,7 +152,7 @@ impl core::fmt::Display for Stats<FskStats> {
 
 #[cfg(test)]
 mod test {
-    use crate::subghz::{CmdStatus, LoRaStats, Stats, StatusMode};
+    use super::{CmdStatus, LoRaStats, Stats, StatusMode};
 
     #[test]
     fn mixed() {

--- a/hal/src/subghz/status.rs
+++ b/hal/src/subghz/status.rs
@@ -115,7 +115,7 @@ impl CmdStatus {
 ///
 /// This is returned by [`status`].
 ///
-/// [`status`]: crate::subghz::SubGhz::status
+/// [`status`]: super::SubGhz::status
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Status(u8);
 

--- a/hal/src/subghz/tcxo_mode.rs
+++ b/hal/src/subghz/tcxo_mode.rs
@@ -1,4 +1,4 @@
-use crate::subghz::Timeout;
+use super::Timeout;
 
 /// TCXO trim.
 ///
@@ -78,7 +78,7 @@ impl TcxoTrim {
 ///
 /// Argument of [`set_tcxo_mode`].
 ///
-/// [`set_tcxo_mode`]: crate::subghz::SubGhz::set_tcxo_mode
+/// [`set_tcxo_mode`]: super::SubGhz::set_tcxo_mode
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TcxoMode {

--- a/hal/src/subghz/timeout.rs
+++ b/hal/src/subghz/timeout.rs
@@ -1,6 +1,6 @@
 use core::time::Duration;
 
-use crate::subghz::ValueError;
+use super::ValueError;
 
 const fn abs_diff(a: u64, b: u64) -> u64 {
     if a > b {
@@ -20,9 +20,9 @@ const fn abs_diff(a: u64, b: u64) -> u64 {
 /// Each timeout has 3 bytes, with a resolution of 15.625µs per bit, giving a
 /// range of 0s to 262.143984375s.
 ///
-/// [`set_rx`]: crate::subghz::SubGhz::set_rx
-/// [`set_tx`]: crate::subghz::SubGhz::set_tx
-/// [`TcxoMode`]: crate::subghz::TcxoMode
+/// [`set_rx`]: super::SubGhz::set_rx
+/// [`set_tx`]: super::SubGhz::set_tx
+/// [`TcxoMode`]: super::TcxoMode
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Timeout {

--- a/hal/src/subghz/tx_params.rs
+++ b/hal/src/subghz/tx_params.rs
@@ -1,6 +1,6 @@
 /// Power amplifier ramp time for FSK, MSK, and LoRa modulation.
 ///
-/// Argument of [`set_ramp_time`][`crate::subghz::TxParams::set_ramp_time`].
+/// Argument of [`set_ramp_time`][`super::TxParams::set_ramp_time`].
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
@@ -60,7 +60,7 @@ impl From<RampTime> for embedded_time::duration::Microseconds {
 }
 /// Transmit parameters, output power and power amplifier ramp up time.
 ///
-/// Argument of [`set_tx_params`][`crate::subghz::SubGhz::set_tx_params`].
+/// Argument of [`set_tx_params`][`super::SubGhz::set_tx_params`].
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TxParams {
@@ -70,27 +70,27 @@ pub struct TxParams {
 impl TxParams {
     /// Optimal power setting for +15dBm output power with the low-power PA.
     ///
-    /// This must be used with [`PaConfig::LP_15`](crate::subghz::PaConfig::LP_15).
+    /// This must be used with [`PaConfig::LP_15`](super::PaConfig::LP_15).
     pub const LP_15: TxParams = TxParams::new().set_power(0x0E);
 
     /// Optimal power setting for +14dBm output power with the low-power PA.
     ///
-    /// This must be used with [`PaConfig::LP_14`](crate::subghz::PaConfig::LP_14).
+    /// This must be used with [`PaConfig::LP_14`](super::PaConfig::LP_14).
     pub const LP_14: TxParams = TxParams::new().set_power(0x0E);
 
     /// Optimal power setting for +10dBm output power with the low-power PA.
     ///
-    /// This must be used with [`PaConfig::LP_10`](crate::subghz::PaConfig::LP_10).
+    /// This must be used with [`PaConfig::LP_10`](super::PaConfig::LP_10).
     pub const LP_10: TxParams = TxParams::new().set_power(0x0D);
 
     /// Optimal power setting for the high-power PA.
     ///
     /// This must be used with one of:
     ///
-    /// * [`PaConfig::HP_22`](crate::subghz::PaConfig::HP_22)
-    /// * [`PaConfig::HP_20`](crate::subghz::PaConfig::HP_20)
-    /// * [`PaConfig::HP_17`](crate::subghz::PaConfig::HP_17)
-    /// * [`PaConfig::HP_14`](crate::subghz::PaConfig::HP_14)
+    /// * [`PaConfig::HP_22`](super::PaConfig::HP_22)
+    /// * [`PaConfig::HP_20`](super::PaConfig::HP_20)
+    /// * [`PaConfig::HP_17`](super::PaConfig::HP_17)
+    /// * [`PaConfig::HP_14`](super::PaConfig::HP_14)
     pub const HP: TxParams = TxParams::new().set_power(0x16);
 
     /// Create a new `TxParams` struct.
@@ -142,7 +142,7 @@ impl TxParams {
     /// # assert_eq!(TX_PARAMS.as_slice()[1], 0x00);
     /// ```
     ///
-    /// [`set_pa_config`]: crate::subghz::SubGhz::set_pa_config
+    /// [`set_pa_config`]: super::SubGhz::set_pa_config
     #[must_use = "set_power returns a modified TxParams"]
     pub const fn set_power(mut self, power: u8) -> TxParams {
         self.buf[1] = power;

--- a/hal/src/subghz/value_error.rs
+++ b/hal/src/subghz/value_error.rs
@@ -2,7 +2,7 @@
 ///
 /// Used by [`Timeout::from_duration`].
 ///
-/// [`Timeout::from_duration`]: crate::subghz::Timeout::from_duration
+/// [`Timeout::from_duration`]: super::Timeout::from_duration
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ValueError<T> {


### PR DESCRIPTION
@newAM As I mentioned, here are some changes that makes it easier to reuse portions of the subghz HAL in embassy. Essentially replacing crate:: imports using super, to allow relative import paths.