### PR TITLE
Fix representation Spreading factors 10 to 12

### DIFF
--- a/hal/src/subghz/mod_params.rs
+++ b/hal/src/subghz/mod_params.rs
@@ -623,11 +623,11 @@ pub enum SpreadingFactor {
     /// Spreading factor 9.
     Sf9 = 0x09,
     /// Spreading factor 10.
-    Sf10 = 0xA0,
+    Sf10 = 0x0A,
     /// Spreading factor 11.
-    Sf11 = 0xB0,
+    Sf11 = 0x0B,
     /// Spreading factor 12.
-    Sf12 = 0xC0,
+    Sf12 = 0x0C,
 }
 
 impl From<SpreadingFactor> for u8 {


### PR DESCRIPTION
The spreading factors for Lora were represented in the enum as 0xA0 0xB0 0xC0, instead of 0x0A 0x0B 0x0C. (Un?)surprisingly, Err(1) is the norm of returned command status when setting the parameters, so there was no clue when trying to set them.