### PR TITLE
Add AES function to select swapping mode

### DIFF
--- a/hal/src/aes.rs
+++ b/hal/src/aes.rs
@@ -61,17 +61,23 @@ impl From<Mode> for u8 {
     }
 }
 
+/// Data swapping mode
+#[derive(Clone, Copy, Debug)]
 #[repr(u8)]
 #[allow(dead_code)]
-#[derive(Clone, Copy, Debug)]
 pub enum SwapMode {
+    /// No swapping
     NoSwap = 0b00,
+    /// Swap half words on each 32-bit word
     HalfWordSwap = 0b01,
+    /// Swap bytes on each 32-bit word
     ByteSwap = 0b10,
+    /// Swap bits on each 32-bit word
     BitSwap = 0b11,
 }
 
 impl SwapMode {
+    /// Return the bit value for the DATATYPE field in the CR register
     pub const fn bits(self) -> u8 {
         self as u8
     }

--- a/hal/src/aes.rs
+++ b/hal/src/aes.rs
@@ -114,7 +114,7 @@ impl Aes {
         Self::enable_clock(rcc);
         unsafe { Self::pulse_reset(rcc) };
 
-        Aes { 
+        Aes {
             aes,
             swap_mode: SwapMode::NoSwap,
         }
@@ -231,9 +231,9 @@ impl Aes {
     #[inline]
     pub unsafe fn steal() -> Aes {
         let dp: pac::Peripherals = pac::Peripherals::steal();
-        Aes { 
-            aes: dp.AES, 
-            swap_mode: SwapMode::NoSwap 
+        Aes {
+            aes: dp.AES,
+            swap_mode: SwapMode::NoSwap,
         }
     }
 
@@ -596,7 +596,6 @@ impl Aes {
     pub fn set_dataswap(&mut self, mode: SwapMode) {
         self.swap_mode = mode;
     }
-    
 
     /// Encrypt using the electronic codebook chaining (ECB) algorithm.
     ///
@@ -687,7 +686,7 @@ impl Aes {
         const CHMOD2: bool = ALGO.chmod2();
         const CHMOD10: u8 = ALGO.chmod10();
         const MODE: u8 = Mode::Encryption.bits();
-        
+
         let keysize: KeySize = self.set_key(key);
         let swap = self.swap_mode.bits();
 


### PR DESCRIPTION
The AES peripheral allows for swapping of the input & output block.

This PR adds a function to select the mode. Existing implementations should not break, since the new function relies on a parameter of the struct and is used internally in each encrypt/decrypt function.